### PR TITLE
Remove fees on first and last hop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+*~
 /venv-populus/
+/venv/
 .pytest_cache/
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -593,6 +593,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         for (uint i = _path.length; i > 0; i--) {
             // the address of the receiver is _path[i-1]
             address sender;
+            uint64 fee;
             if (i == 1) {
                 sender = _from;
             } else {
@@ -602,7 +603,12 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             Trustline memory trustline = _loadTrustline(sender, _path[i-1]);
             _applyInterests(trustline);
 
-            uint64 fee = _calculateFees(forwardedValue, trustline.balances.balance, capacityImbalanceFeeDivisor);
+            if (i == _path.length) {
+                fee = 0; // receiver should not get a fee
+            } else {
+                fee = _calculateFees(forwardedValue, trustline.balances.balance, capacityImbalanceFeeDivisor);
+            }
+
             // forward the value + the fee
             forwardedValue += fee;
             //Overflow check

--- a/tests/test_currency_network_interests.py
+++ b/tests/test_currency_network_interests.py
@@ -48,7 +48,15 @@ def currency_network_contract_custom_interests_safe_ripple(web3):
     return deploy_network(web3, 'TestCoin', 'T', 6, 0, 0, custom_interests=True, prevent_mediator_interests=True)
 
 
-def test_interests_positive_balance(ethereum_tester_session, currency_network_contract_default_interests, accounts):
+@pytest.fixture(params=['transfer', 'transferReceiverPays'])
+def transfer_function_name(request):
+    return request.param
+
+
+def test_interests_positive_balance(ethereum_tester_session,
+                                    currency_network_contract_default_interests,
+                                    accounts,
+                                    transfer_function_name):
     '''Tests interests with a default setting'''
 
     contract = currency_network_contract_default_interests
@@ -58,7 +66,8 @@ def test_interests_positive_balance(ethereum_tester_session, currency_network_co
                                   100000000).transact()
 
     ethereum_tester_session.time_travel(current_time + SECONDS_PER_YEAR)
-    contract.functions.transfer(accounts[1], 1, 2, [accounts[1]]).transact({'from': accounts[0]})
+    getattr(contract.functions, transfer_function_name)(accounts[1], 1, 2, [accounts[1]]).transact(
+        {'from': accounts[0]})
 
     balance = contract.functions.balance(accounts[0], accounts[1]).call()
 
@@ -66,8 +75,10 @@ def test_interests_positive_balance(ethereum_tester_session, currency_network_co
     assert balance + 1 == pytest.approx(100000000 * exp(0.01), abs=1)
 
 
-def test_interests_high_value(ethereum_tester_session, currency_network_contract_custom_interests_safe_ripple,
-                              accounts):
+def test_interests_high_value(ethereum_tester_session,
+                              currency_network_contract_custom_interests_safe_ripple,
+                              accounts,
+                              transfer_function_name):
     '''Test interests with high interests'''
 
     contract = currency_network_contract_custom_interests_safe_ripple
@@ -78,7 +89,8 @@ def test_interests_high_value(ethereum_tester_session, currency_network_contract
                                   1000000000000000000).transact()
 
     ethereum_tester_session.time_travel(current_time + SECONDS_PER_YEAR)
-    contract.functions.transfer(accounts[1], 1, 2, [accounts[1]]).transact({'from': accounts[0]})
+    getattr(contract.functions, transfer_function_name)(accounts[1], 1, 2, [accounts[1]]).transact(
+        {'from': accounts[0]})
 
     balance = contract.functions.balance(accounts[0], accounts[1]).call()
 
@@ -86,7 +98,10 @@ def test_interests_high_value(ethereum_tester_session, currency_network_contract
     assert balance + 1 == pytest.approx(1000000000000000000 * exp(0.20), rel=0.01)  # 1%
 
 
-def test_interests_negative_balance(ethereum_tester_session, currency_network_contract_default_interests, accounts):
+def test_interests_negative_balance(ethereum_tester_session,
+                                    currency_network_contract_default_interests,
+                                    accounts,
+                                    transfer_function_name):
     '''Tests interests with a default setting with a negative balance'''
 
     contract = currency_network_contract_default_interests
@@ -97,7 +112,8 @@ def test_interests_negative_balance(ethereum_tester_session, currency_network_co
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
 
     ethereum_tester_session.time_travel(current_time + SECONDS_PER_YEAR)
-    contract.functions.transfer(accounts[1], 1, 2, [accounts[1]]).transact({'from': accounts[0]})
+    getattr(contract.functions, transfer_function_name)(accounts[1], 1, 2, [accounts[1]]).transact(
+        {'from': accounts[0]})
 
     balance = contract.functions.balance(accounts[0], accounts[1]).call()
 
@@ -105,7 +121,10 @@ def test_interests_negative_balance(ethereum_tester_session, currency_network_co
     assert balance + 1 == pytest.approx(-100000000 * exp(0.01), abs=1)
 
 
-def test_no_interests(ethereum_tester_session, currency_network_contract_no_interests, accounts):
+def test_no_interests(ethereum_tester_session,
+                      currency_network_contract_no_interests,
+                      accounts,
+                      transfer_function_name):
     '''Tests that we can have a network with no interests'''
 
     contract = currency_network_contract_no_interests
@@ -116,24 +135,30 @@ def test_no_interests(ethereum_tester_session, currency_network_contract_no_inte
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
 
     ethereum_tester_session.time_travel(current_time + SECONDS_PER_YEAR)
-    contract.functions.transfer(accounts[1], 1, 2, [accounts[1]]).transact({'from': accounts[0]})
+    getattr(contract.functions, transfer_function_name)(accounts[1], 1, 2, [accounts[1]]).transact(
+        {'from': accounts[0]})
 
     balance = contract.functions.balance(accounts[0], accounts[1]).call()
 
     assert balance == 100000000 - 1
 
 
-def test_custom_interests(ethereum_tester_session, currency_network_contract_custom_interests_safe_ripple, accounts):
+def test_custom_interests(ethereum_tester_session,
+                          currency_network_contract_custom_interests_safe_ripple,
+                          accounts,
+                          transfer_function_name):
     '''Tests custom interests setting, set with setAccount'''
 
     contract = currency_network_contract_custom_interests_safe_ripple
     contract.transact().setAccount(accounts[0], accounts[1], 0, 2000000000, 0, 1234, 0, 0, 0, 0)
     current_time = int(time.time())
     ethereum_tester_session.time_travel(current_time + SECONDS_PER_YEAR)
-    contract.functions.transfer(accounts[1], 100000000, 2000000, [accounts[1]]).transact({'from': accounts[0]})
+    getattr(contract.functions, transfer_function_name)(accounts[1], 100000000, 2000000, [accounts[1]]).transact(
+        {'from': accounts[0]})
 
     ethereum_tester_session.time_travel(current_time + 2 * SECONDS_PER_YEAR)
-    contract.functions.transfer(accounts[1], 1, 2, [accounts[1]]).transact({'from': accounts[0]})
+    getattr(contract.functions, transfer_function_name)(accounts[1], 1, 2, [accounts[1]]).transact(
+        {'from': accounts[0]})
 
     balance = contract.functions.balance(accounts[0], accounts[1]).call()
 
@@ -141,7 +166,9 @@ def test_custom_interests(ethereum_tester_session, currency_network_contract_cus
 
 
 def test_custom_interests_postive_balance(ethereum_tester_session,
-                                          currency_network_contract_custom_interests_safe_ripple, accounts):
+                                          currency_network_contract_custom_interests_safe_ripple,
+                                          accounts,
+                                          transfer_function_name):
     '''Tests custom interests setting, set with setAccount'''
 
     contract = currency_network_contract_custom_interests_safe_ripple
@@ -151,7 +178,8 @@ def test_custom_interests_postive_balance(ethereum_tester_session,
                                   100000000).transact()
 
     ethereum_tester_session.time_travel(current_time + SECONDS_PER_YEAR)
-    contract.functions.transfer(accounts[1], 1, 2, [accounts[1]]).transact({'from': accounts[0]})
+    getattr(contract.functions, transfer_function_name)(accounts[1], 1, 2, [accounts[1]]).transact(
+        {'from': accounts[0]})
 
     balance = contract.functions.balance(accounts[0], accounts[1]).call()
 
@@ -165,18 +193,23 @@ def test_setting_default_and_custom_interests_fails(web3, accounts):
                        prevent_mediator_interests=False)
 
 
-def test_safe_interest_allows_direct_transactions(currency_network_contract_custom_interests_safe_ripple, accounts):
+def test_safe_interest_allows_direct_transactions(currency_network_contract_custom_interests_safe_ripple,
+                                                  accounts,
+                                                  transfer_function_name):
     '''Tests that the safeInterestRippling does not prevent legit transactions'''
 
     contract = currency_network_contract_custom_interests_safe_ripple
     contract.functions.setAccount(accounts[0], accounts[1], 1000000, 2000000, 100, 200, 0, 0, 0, 0).transact()
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
 
-    contract.transact({'from': accounts[0]}).transfer(accounts[1], 1, 2, [accounts[1]])
+    getattr(contract.functions, transfer_function_name)(accounts[1], 1, 2, [accounts[1]]).transact(
+        {'from': accounts[0]})
 
 
 def test_safe_interest_allows_transactions_mediated(ethereum_tester_session,
-                                                    currency_network_contract_custom_interests_safe_ripple, accounts):
+                                                    currency_network_contract_custom_interests_safe_ripple,
+                                                    accounts,
+                                                    transfer_function_name):
     '''Tests that the safeInterestRippling does not prevent legit transactions'''
 
     contract = currency_network_contract_custom_interests_safe_ripple
@@ -188,15 +221,18 @@ def test_safe_interest_allows_transactions_mediated(ethereum_tester_session,
                                   0).transact()
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
 
-    contract.functions.transfer(accounts[2], 1, 2, [accounts[1], accounts[2]]).transact({'from': accounts[0]})
+    getattr(contract.functions, transfer_function_name)(accounts[2], 1, 2, [accounts[1], accounts[2]]).transact(
+        {'from': accounts[0]})
 
 
 def test_safe_interest_disallows_transactions_mediated_if_interests_increase(
-        ethereum_tester_session,
-        currency_network_contract_custom_interests_safe_ripple,
-        accounts):
+    ethereum_tester_session,
+    currency_network_contract_custom_interests_safe_ripple,
+    accounts,
+    transfer_function_name
+):
     '''Tests that the safeInterestRippling prevents transaction where the mediator would loose money,
-     because of interests'''
+    because of interests'''
 
     contract = currency_network_contract_custom_interests_safe_ripple
     current_time = int(time.time())
@@ -207,12 +243,16 @@ def test_safe_interest_disallows_transactions_mediated_if_interests_increase(
                                   0).transact()
 
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
-        contract.functions.transfer(accounts[2], 1, 2, [accounts[1], accounts[2]]).transact({'from': accounts[0]})
+        getattr(contract.functions, transfer_function_name)(accounts[2], 1, 2, [accounts[1], accounts[2]]).transact(
+            {'from': accounts[0]})
 
 
 def test_safe_interest_allows_transactions_mediated_solves_imbalance(
-        ethereum_tester_session,
-        currency_network_contract_custom_interests_safe_ripple, accounts):
+    ethereum_tester_session,
+    currency_network_contract_custom_interests_safe_ripple,
+    accounts,
+    transfer_function_name
+):
     '''Tests that the safeInterestRippling allows transactions that reduce imbalances'''
 
     contract = currency_network_contract_custom_interests_safe_ripple
@@ -223,12 +263,16 @@ def test_safe_interest_allows_transactions_mediated_solves_imbalance(
     contract.functions.setAccount(accounts[1], accounts[2], 1000000, 2000000, 100, 200, 0, 0, current_time,
                                   100).transact()
 
-    contract.functions.transfer(accounts[2], 1, 2, [accounts[1], accounts[2]]).transact({'from': accounts[0]})
+    getattr(contract.functions, transfer_function_name)(accounts[2], 1, 2, [accounts[1], accounts[2]]).transact(
+        {'from': accounts[0]})
 
 
 def test_safe_interest_disallows_transactions_mediated_solves_imbalance_but_overflows(
-        ethereum_tester_session,
-        currency_network_contract_custom_interests_safe_ripple, accounts):
+    ethereum_tester_session,
+    currency_network_contract_custom_interests_safe_ripple,
+    accounts,
+    transfer_function_name
+):
     '''Tests that the safeInterestRippling disallows transactions that make mediators loose money'''
 
     contract = currency_network_contract_custom_interests_safe_ripple
@@ -240,11 +284,14 @@ def test_safe_interest_disallows_transactions_mediated_solves_imbalance_but_over
                                   100).transact()
 
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
-        contract.functions.transfer(accounts[2], 201, 2, [accounts[1], accounts[2]]).transact({'from': accounts[0]})
+        getattr(contract.functions, transfer_function_name)(accounts[2], 201, 2, [accounts[1], accounts[2]]).transact(
+            {'from': accounts[0]})
 
 
 def test_negative_interests_default_positive_balance(ethereum_tester_session,
-                                                     currency_network_contract_negative_interests, accounts):
+                                                     currency_network_contract_negative_interests,
+                                                     accounts,
+                                                     transfer_function_name):
     '''Tests interests with a default setting with negative interests'''
 
     contract = currency_network_contract_negative_interests
@@ -255,7 +302,8 @@ def test_negative_interests_default_positive_balance(ethereum_tester_session,
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
 
     ethereum_tester_session.time_travel(current_time + SECONDS_PER_YEAR)
-    contract.functions.transfer(accounts[1], 1, 2, [accounts[1]]).transact({'from': accounts[0]})
+    getattr(contract.functions, transfer_function_name)(accounts[1], 1, 2, [accounts[1]]).transact(
+        {'from': accounts[0]})
 
     balance = contract.call().balance(accounts[0], accounts[1])
 
@@ -263,7 +311,9 @@ def test_negative_interests_default_positive_balance(ethereum_tester_session,
 
 
 def test_negative_interests_default_negative_balance(ethereum_tester_session,
-                                                     currency_network_contract_negative_interests, accounts):
+                                                     currency_network_contract_negative_interests,
+                                                     accounts,
+                                                     transfer_function_name):
     '''Tests interests with negative interests with a negative balance'''
 
     contract = currency_network_contract_negative_interests
@@ -274,7 +324,8 @@ def test_negative_interests_default_negative_balance(ethereum_tester_session,
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
 
     ethereum_tester_session.time_travel(current_time + SECONDS_PER_YEAR)
-    contract.functions.transfer(accounts[1], 1, 2, [accounts[1]]).transact({'from': accounts[0]})
+    getattr(contract.functions, transfer_function_name)(accounts[1], 1, 2, [accounts[1]]).transact(
+        {'from': accounts[0]})
 
     balance = contract.functions.balance(accounts[0], accounts[1]).call()
 
@@ -286,13 +337,15 @@ BALANCE_WIDTH = 72
 INTEREST_WIDTH = 16
 
 
-def test_interests_overflow(ethereum_tester_session, currency_network_contract_custom_interests_safe_ripple, accounts):
+def test_interests_overflow(ethereum_tester_session,
+                            currency_network_contract_custom_interests_safe_ripple,
+                            accounts):
     contract = currency_network_contract_custom_interests_safe_ripple
     current_time = int(time.time())
     ethereum_tester_session.time_travel(current_time + 10)
-    contract.functions.setAccount(accounts[0], accounts[1], 2**CREDITLINE_WIDTH-1, 2**CREDITLINE_WIDTH-1,
-                                  2 ** (INTEREST_WIDTH-1) - 1, 2**(INTEREST_WIDTH-1)-1, 0, 0, current_time,
-                                  2**CREDITLINE_WIDTH-1).transact()
+    contract.functions.setAccount(accounts[0], accounts[1], 2 ** CREDITLINE_WIDTH - 1, 2 ** CREDITLINE_WIDTH - 1,
+                                  2 ** (INTEREST_WIDTH - 1) - 1, 2 ** (INTEREST_WIDTH - 1) - 1, 0, 0, current_time,
+                                  2 ** CREDITLINE_WIDTH - 1).transact()
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
 
     ethereum_tester_session.time_travel(current_time + int(1.6923 * SECONDS_PER_YEAR))
@@ -300,7 +353,7 @@ def test_interests_overflow(ethereum_tester_session, currency_network_contract_c
 
     balance = contract.functions.balance(accounts[0], accounts[1]).call()
 
-    assert balance + 1 == 2**(BALANCE_WIDTH-1) - 1
+    assert balance + 1 == 2 ** (BALANCE_WIDTH - 1) - 1
 
 
 def test_interests_underflow(ethereum_tester_session,
@@ -308,10 +361,10 @@ def test_interests_underflow(ethereum_tester_session,
                              accounts):
     contract = currency_network_contract_custom_interests_safe_ripple
     current_time = int(time.time())
-    ethereum_tester_session.time_travel(current_time+10)
-    contract.functions.setAccount(accounts[0], accounts[1], 2**CREDITLINE_WIDTH-1, 2**CREDITLINE_WIDTH-1,
-                                  2 ** (INTEREST_WIDTH-1) - 1, 2**(INTEREST_WIDTH-1)-1, 0, 0, current_time,
-                                  -(2**CREDITLINE_WIDTH-1)).transact()
+    ethereum_tester_session.time_travel(current_time + 10)
+    contract.functions.setAccount(accounts[0], accounts[1], 2 ** CREDITLINE_WIDTH - 1, 2 ** CREDITLINE_WIDTH - 1,
+                                  2 ** (INTEREST_WIDTH - 1) - 1, 2 ** (INTEREST_WIDTH - 1) - 1, 0, 0, current_time,
+                                  -(2 ** CREDITLINE_WIDTH - 1)).transact()
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
 
     ethereum_tester_session.time_travel(current_time + int(2.23 * SECONDS_PER_YEAR))
@@ -322,13 +375,14 @@ def test_interests_underflow(ethereum_tester_session,
     contract.functions.transfer(accounts[0], 1, 0, [accounts[0]]).transact({'from': accounts[1]})
     balance = contract.functions.balance(accounts[0], accounts[1]).call()
 
-    assert balance - 1 == - (2**(BALANCE_WIDTH - 1) - 1)
+    assert balance - 1 == - (2 ** (BALANCE_WIDTH - 1) - 1)
 
 
 def test_interests_over_change_in_trustline(
-        ethereum_tester_session,
-        currency_network_contract_custom_interests_safe_ripple,
-        accounts):
+    ethereum_tester_session,
+    currency_network_contract_custom_interests_safe_ripple,
+    accounts
+):
     contract = currency_network_contract_custom_interests_safe_ripple
     current_time = int(time.time())
     ethereum_tester_session.time_travel(current_time + 10)
@@ -348,9 +402,10 @@ def test_interests_over_change_in_trustline(
 
 
 def test_payback_interests_even_over_creditline(
-        ethereum_tester_session,
-        currency_network_contract_custom_interests_safe_ripple,
-        accounts):
+    ethereum_tester_session,
+    currency_network_contract_custom_interests_safe_ripple,
+    accounts
+):
     contract = currency_network_contract_custom_interests_safe_ripple
     current_time = int(time.time())
     ethereum_tester_session.time_travel(current_time + 10)
@@ -367,9 +422,10 @@ def test_payback_interests_even_over_creditline(
 
 
 def test_interests_over_creditline_is_usable(
-        ethereum_tester_session,
-        currency_network_contract_custom_interests_safe_ripple,
-        accounts):
+    ethereum_tester_session,
+    currency_network_contract_custom_interests_safe_ripple,
+    accounts
+):
     contract = currency_network_contract_custom_interests_safe_ripple
     current_time = int(time.time())
     ethereum_tester_session.time_travel(current_time + 10)

--- a/tests/test_currency_network_receiver_pays.py
+++ b/tests/test_currency_network_receiver_pays.py
@@ -1,0 +1,139 @@
+#! pytest
+
+import pytest
+from tldeploy.core import deploy_network
+import eth_tester.exceptions
+
+trustlines = [(0, 1, 100, 150),
+              (1, 2, 200, 250),
+              (2, 3, 300, 350),
+              (3, 4, 400, 450),
+              (0, 4, 500, 550)
+              ]  # (A, B, clAB, clBA)
+
+
+@pytest.fixture()
+def currency_network_contract(web3):
+    return deploy_network(web3, name="TestCoin", symbol="T", decimals=6, fee_divisor=100)
+
+
+@pytest.fixture()
+def currency_network_contract_with_trustlines(currency_network_contract, accounts):
+    contract = currency_network_contract
+    for (A, B, clAB, clBA) in trustlines:
+        contract.functions.setAccount(accounts[A], accounts[B], clAB, clBA, 0, 0, 0, 0, 0, 0).transact()
+    return contract
+
+
+def test_transfer_0_mediators(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    contract.functions.transferReceiverPays(accounts[1], 100, 0, [accounts[1]]).transact({'from': accounts[0]})
+    assert contract.functions.balance(accounts[0], accounts[1]).call() == -100
+
+
+def test_transfer_0_mediators_fail_not_enough_credit(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    with pytest.raises(eth_tester.exceptions.TransactionFailed):
+        contract.functions.transferReceiverPays(accounts[1], 151, 0, [accounts[1]]).transact({'from': accounts[0]})
+
+
+def test_transfer_1_mediators(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    contract.functions.transferReceiverPays(accounts[2], 50, 1, [accounts[1], accounts[2]]).transact(
+        {'from': accounts[0]})
+    assert contract.functions.balance(accounts[0], accounts[1]).call() == -50
+    assert contract.functions.balance(accounts[2], accounts[1]).call() == 50 - 1
+
+
+def test_transfer_1_mediator_enough_credit_because_of_fee(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    contract.functions.transferReceiverPays(
+        accounts[0],
+        100 + 2,
+        2,
+        [accounts[1], accounts[0]]).transact({'from': accounts[2]})
+
+
+def test_transfer_3_mediators(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    contract.functions.transferReceiverPays(accounts[4], 100, 6, [accounts[1],
+                                                                  accounts[2],
+                                                                  accounts[3],
+                                                                  accounts[4]]).transact({'from': accounts[0]})
+    assert contract.functions.balance(accounts[0], accounts[1]).call() == -100
+    assert contract.functions.balance(accounts[1], accounts[2]).call() == -100 + 2
+    assert contract.functions.balance(accounts[2], accounts[3]).call() == -100 + 3
+    assert contract.functions.balance(accounts[4], accounts[3]).call() == 100 - 4
+
+
+def test_spendable(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    A, B, *rest = accounts
+    assert contract.functions.spendableTo(A, B).call() == 150
+    assert contract.functions.spendableTo(B, A).call() == 100
+    contract.functions.transferReceiverPays(B, 40, 0, [B]).transact({"from": A})
+    assert contract.functions.spendableTo(A, B).call() == 110
+    assert contract.functions.spendableTo(B, A).call() == 140
+
+
+def test_max_fee(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    with pytest.raises(eth_tester.exceptions.TransactionFailed):
+        contract.functions.transferReceiverPays(accounts[1], 100, 1, [accounts[1], accounts[2]]).transact(
+            {'from': accounts[0]})
+
+
+def test_max_fee_3_mediators(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    with pytest.raises(eth_tester.exceptions.TransactionFailed):
+        contract.functions.transferReceiverPays(accounts[4], 50, 2,
+                                                [accounts[1],
+                                                 accounts[2],
+                                                 accounts[3],
+                                                 accounts[4]]).transact(
+            {'from': accounts[0]})
+
+
+def test_send_back_with_fees(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    assert contract.functions.balance(accounts[0], accounts[1]).call() == 0
+    contract.functions.transferReceiverPays(accounts[2], 120, 2, [accounts[1], accounts[2]]).transact(
+        {'from': accounts[0]})
+    contract.functions.transferReceiverPays(accounts[2], 20, 1, [accounts[2]]).transact(
+        {'from': accounts[1]})
+    assert contract.functions.balance(accounts[0], accounts[1]).call() == -120
+    assert contract.functions.balance(accounts[2], accounts[1]).call() == 20 + 118
+    contract.functions.transferReceiverPays(accounts[0], 120, 0, [accounts[1], accounts[0]]).transact(
+        {'from': accounts[2]})
+    assert contract.functions.balance(accounts[0], accounts[1]).call() == 0
+    assert contract.functions.balance(accounts[2], accounts[1]).call() == 20 - 2
+
+
+def test_send_more_with_fees(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    assert contract.functions.balance(accounts[0], accounts[1]).call() == 0
+    contract.functions.transferReceiverPays(accounts[2], 120, 2, [accounts[1], accounts[2]]).transact(
+        {'from': accounts[0]})
+    assert contract.functions.balance(accounts[0], accounts[1]).call() == -120
+    contract.functions.transferReceiverPays(accounts[0], 200, 1, [accounts[1], accounts[0]]).transact(
+        {'from': accounts[2]})
+    assert contract.functions.balance(accounts[0], accounts[1]).call() == 80 - 1
+    assert contract.functions.balance(accounts[2], accounts[1]).call() == -80 - 2
+
+
+def test_transfer_1_received(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    contract.functions.transferReceiverPays(accounts[4], 4, 3, [accounts[1],
+                                                                accounts[2],
+                                                                accounts[3],
+                                                                accounts[4]]).transact({'from': accounts[0]})
+    assert contract.functions.balance(accounts[4], accounts[3]).call() == 1
+
+
+def test_transfer_0_received(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    with pytest.raises(eth_tester.exceptions.TransactionFailed):
+        contract.functions.transferReceiverPays(accounts[4], 3, 3, [accounts[1],
+                                                                    accounts[2],
+                                                                    accounts[3],
+                                                                    accounts[4]]).transact({'from': accounts[0]})


### PR DESCRIPTION
As decided we remove the fees for the last hop, as the receiver should
not receive a fee additional to the amount he already receives.
Closes #154 

Remove the fees for the first hop if the receiver pays in alignment
to removing the fees for the last hop if the sender pays.
Closes #155

Also make transferReceiverPays function public available so that also
other users can use it.
Closes #140