### PR TITLE
Feature/rounding fees up

### DIFF
--- a/tests/test_currency_network_fees.py
+++ b/tests/test_currency_network_fees.py
@@ -77,10 +77,17 @@ def test_spendable(currency_network_contract_with_trustlines, accounts):
     assert contract.functions.spendableTo(B, A).call() == 140
 
 
+def test_rounding_fee(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    # test that fee is really 1%
+    contract.functions.transfer(accounts[2], 99, 1, [accounts[1], accounts[2]]).transact({'from': accounts[0]})
+    assert contract.functions.balance(accounts[0], accounts[1]).call() == -99 - 1
+
+
 def test_max_fee(currency_network_contract_with_trustlines, accounts):
     contract = currency_network_contract_with_trustlines
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
-        contract.functions.transfer(accounts[1], 100, 1, [accounts[1], accounts[2]]).transact({'from': accounts[0]})
+        contract.functions.transfer(accounts[1], 110, 1, [accounts[1], accounts[2]]).transact({'from': accounts[0]})
 
 
 def test_send_back_with_fees(currency_network_contract_with_trustlines, accounts):

--- a/tests/test_currency_network_receiver_pays.py
+++ b/tests/test_currency_network_receiver_pays.py
@@ -163,12 +163,17 @@ def test_transfer_0_received(currency_network_contract_with_trustlines, accounts
 
 @pytest.mark.parametrize('value', [4, 100, 101, 102, 1000, 9999, 10000, 10001, 50000, 50506, 123456])
 def test_fees_are_the_same(currency_network_contract_with_high_trustlines, accounts, value):
+    """Test that the fees are the same, no matter if the sender or the receiver pays the fees
+    For that we check that if someone sends a transfer where the receiver pays, so `value` is sent but a smaller
+    amount `received` is received, it will result in the same value sent if sender pays is chosen and `received`
+    is used as value for this transfer.
+    Because the fee function is not injective we allow for a difference of 1
+    """
     contract = currency_network_contract_with_high_trustlines
     contract.functions.transferReceiverPays(accounts[3], value, 10000,
                                             [accounts[1], accounts[2], accounts[3]]).transact(
         {'from': accounts[0]})
     return_value = contract.functions.balance(accounts[3], accounts[2]).call()
-    print(return_value)
     contract.functions.transfer(accounts[3], return_value, 10000, [accounts[2], accounts[4], accounts[3]]).transact(
         {'from': accounts[0]})
     balance_sender = contract.functions.balance(accounts[0], accounts[2]).call()

--- a/tests/test_currency_network_receiver_pays.py
+++ b/tests/test_currency_network_receiver_pays.py
@@ -25,6 +25,21 @@ def currency_network_contract_with_trustlines(currency_network_contract, account
     return contract
 
 
+@pytest.fixture()
+def currency_network_contract_with_high_trustlines(currency_network_contract, accounts):
+    contract = currency_network_contract
+    creditline = 1000000
+    contract.functions.setAccount(accounts[0], accounts[1], creditline, creditline, 0, 0, 0, 0, 0, 0).transact()
+    contract.functions.setAccount(accounts[1], accounts[2], creditline, creditline, 0, 0, 0, 0, 0, 0).transact()
+    contract.functions.setAccount(accounts[2], accounts[3], creditline, creditline, 0, 0, 0, 0, 0, 0).transact()
+
+    contract.functions.setAccount(accounts[0], accounts[2], creditline, creditline, 0, 0, 0, 0, 0, 0).transact()
+    contract.functions.setAccount(accounts[2], accounts[4], creditline, creditline, 0, 0, 0, 0, 0, 0).transact()
+    contract.functions.setAccount(accounts[4], accounts[3], creditline, creditline, 0, 0, 0, 0, 0, 0).transact()
+
+    return contract
+
+
 def test_transfer_0_mediators(currency_network_contract_with_trustlines, accounts):
     contract = currency_network_contract_with_trustlines
     contract.functions.transferReceiverPays(accounts[1], 100, 0, [accounts[1]]).transact({'from': accounts[0]})
@@ -56,14 +71,14 @@ def test_transfer_1_mediator_enough_credit_because_of_fee(currency_network_contr
 
 def test_transfer_3_mediators(currency_network_contract_with_trustlines, accounts):
     contract = currency_network_contract_with_trustlines
-    contract.functions.transferReceiverPays(accounts[4], 100, 6, [accounts[1],
+    contract.functions.transferReceiverPays(accounts[4], 100, 3, [accounts[1],
                                                                   accounts[2],
                                                                   accounts[3],
                                                                   accounts[4]]).transact({'from': accounts[0]})
     assert contract.functions.balance(accounts[0], accounts[1]).call() == -100
-    assert contract.functions.balance(accounts[1], accounts[2]).call() == -100 + 2
-    assert contract.functions.balance(accounts[2], accounts[3]).call() == -100 + 3
-    assert contract.functions.balance(accounts[4], accounts[3]).call() == 100 - 4
+    assert contract.functions.balance(accounts[1], accounts[2]).call() == -100 + 1
+    assert contract.functions.balance(accounts[2], accounts[3]).call() == -100 + 2
+    assert contract.functions.balance(accounts[4], accounts[3]).call() == 100 - 3
 
 
 def test_spendable(currency_network_contract_with_trustlines, accounts):
@@ -76,10 +91,17 @@ def test_spendable(currency_network_contract_with_trustlines, accounts):
     assert contract.functions.spendableTo(B, A).call() == 140
 
 
+def test_rounding_fee(currency_network_contract_with_trustlines, accounts):
+    contract = currency_network_contract_with_trustlines
+    contract.functions.transferReceiverPays(accounts[2], 100, 1, [accounts[1], accounts[2]]).transact(
+        {'from': accounts[0]})
+    assert contract.functions.balance(accounts[2], accounts[1]).call() == 100 - 1
+
+
 def test_max_fee(currency_network_contract_with_trustlines, accounts):
     contract = currency_network_contract_with_trustlines
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
-        contract.functions.transferReceiverPays(accounts[1], 100, 1, [accounts[1], accounts[2]]).transact(
+        contract.functions.transferReceiverPays(accounts[2], 110, 1, [accounts[1], accounts[2]]).transact(
             {'from': accounts[0]})
 
 
@@ -137,3 +159,18 @@ def test_transfer_0_received(currency_network_contract_with_trustlines, accounts
                                                                     accounts[2],
                                                                     accounts[3],
                                                                     accounts[4]]).transact({'from': accounts[0]})
+
+
+@pytest.mark.parametrize('value', [4, 100, 101, 102, 1000, 9999, 10000, 10001, 50000, 50506, 123456])
+def test_fees_are_the_same(currency_network_contract_with_high_trustlines, accounts, value):
+    contract = currency_network_contract_with_high_trustlines
+    contract.functions.transferReceiverPays(accounts[3], value, 10000,
+                                            [accounts[1], accounts[2], accounts[3]]).transact(
+        {'from': accounts[0]})
+    return_value = contract.functions.balance(accounts[3], accounts[2]).call()
+    print(return_value)
+    contract.functions.transfer(accounts[3], return_value, 10000, [accounts[2], accounts[4], accounts[3]]).transact(
+        {'from': accounts[0]})
+    balance_sender = contract.functions.balance(accounts[0], accounts[2]).call()
+    # value can be one wrong because the fee function is not injective
+    assert balance_sender == pytest.approx(-value, abs=1)


### PR DESCRIPTION
Use proper rounding up formular
Use this formular in receiver pays functions and
reverse calculate the fees in the sender pays functions. This results in
the fees beeing the same in almost every case. Only exception is at
points where the fee calculation is not injective, because of the
rounding.
Closes #157

This is based on top of the remove fees PR, so we should merge that first. 