### PR TITLE
Rename updateTrustline to updateCreditlimits

### DIFF
--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -304,7 +304,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
      * @param _creditlineReceived The creditline limit given _debtor
      * @return true, if the credit was successful
      */
-    function updateTrustline(
+    function updateCreditlimits(
         address _debtor,
         uint64 _creditlineGiven,
         uint64 _creditlineReceived
@@ -314,7 +314,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
     {
         address _creditor = msg.sender;
 
-        return _updateTrustline(
+        return _updateCreditlimits(
             _creditor,
             _debtor,
             _creditlineGiven,
@@ -1046,7 +1046,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         }
     }
 
-    function _updateTrustline(
+    function _updateCreditlimits(
         address _creditor,
         address _debtor,
         uint64 _creditlineGiven,

--- a/tests/test_currency_network_basics.py
+++ b/tests/test_currency_network_basics.py
@@ -257,7 +257,7 @@ def test_send_more(currency_network_contract_with_trustlines, accounts):
 def test_update_without_accept_trustline(currency_network_contract, accounts):
     contract = currency_network_contract
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 50, 100).transact({"from": A})
+    contract.functions.updateCreditlimits(B, 50, 100).transact({"from": A})
     assert contract.functions.creditline(A, B).call() == 0
     assert contract.functions.creditline(B, A).call() == 0
     assert (
@@ -275,8 +275,8 @@ def test_update_without_accept_trustline(currency_network_contract, accounts):
 def test_update_with_accept_trustline(currency_network_contract, accounts):
     contract = currency_network_contract
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 50, 100).transact({"from": A})
-    contract.functions.updateTrustline(A, 100, 50).transact({"from": B})
+    contract.functions.updateCreditlimits(B, 50, 100).transact({"from": A})
+    contract.functions.updateCreditlimits(A, 100, 50).transact({"from": B})
     assert contract.functions.creditline(A, B).call() == 50
     assert contract.functions.creditline(B, A).call() == 100
     assert (
@@ -296,8 +296,8 @@ def test_update_with_accept_trustline(currency_network_contract, accounts):
 def test_update_with_accept_different_trustline(currency_network_contract, accounts):
     contract = currency_network_contract
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 50, 100).transact({"from": A})
-    contract.functions.updateTrustline(A, 100, 49).transact({"from": B})
+    contract.functions.updateCreditlimits(B, 50, 100).transact({"from": A})
+    contract.functions.updateCreditlimits(A, 100, 49).transact({"from": B})
     # this was changed so it will accept the lower common ground
     assert contract.functions.creditline(A, B).call() == 49
     assert contract.functions.creditline(B, A).call() == 100
@@ -318,9 +318,9 @@ def test_update_with_accept_different_trustline(currency_network_contract, accou
 def test_update_with_accept_2nd_trustline(currency_network_contract, accounts):
     contract = currency_network_contract
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 50, 100).transact({"from": A})
-    contract.functions.updateTrustline(B, 50, 99).transact({"from": A})
-    contract.functions.updateTrustline(A, 99, 50).transact({"from": B})
+    contract.functions.updateCreditlimits(B, 50, 100).transact({"from": A})
+    contract.functions.updateCreditlimits(B, 50, 99).transact({"from": A})
+    contract.functions.updateCreditlimits(A, 99, 50).transact({"from": B})
     assert contract.functions.creditline(A, B).call() == 50
     assert contract.functions.creditline(B, A).call() == 99
     assert (
@@ -340,9 +340,9 @@ def test_update_with_accept_2nd_trustline(currency_network_contract, accounts):
 def test_cannot_accept_old_trustline(currency_network_contract, accounts):
     contract = currency_network_contract
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 50, 100).transact({"from": A})
-    contract.functions.updateTrustline(B, 50, 99).transact({"from": A})
-    contract.functions.updateTrustline(A, 100, 50).transact({"from": B})
+    contract.functions.updateCreditlimits(B, 50, 100).transact({"from": A})
+    contract.functions.updateCreditlimits(B, 50, 99).transact({"from": A})
+    contract.functions.updateCreditlimits(A, 100, 50).transact({"from": B})
     assert contract.functions.creditline(A, B).call() == 0
     assert contract.functions.creditline(B, A).call() == 0
     assert (
@@ -358,7 +358,7 @@ def test_update_reduce_need_no_accept_trustline(
     A, B, *rest = accounts
     assert contract.functions.creditline(A, B).call() == 100
     assert contract.functions.creditline(B, A).call() == 150
-    contract.functions.updateTrustline(B, 99, 150).transact({"from": A})
+    contract.functions.updateCreditlimits(B, 99, 150).transact({"from": A})
     assert contract.functions.creditline(A, B).call() == 99
     assert contract.functions.creditline(B, A).call() == 150
     assert (
@@ -573,8 +573,8 @@ def test_transfer_event(currency_network_contract_with_trustlines, accounts):
 def test_update_trustline_add_users(currency_network_contract, accounts):
     contract = currency_network_contract
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 50, 100).transact({"from": A})
-    contract.functions.updateTrustline(A, 100, 50).transact({"from": B})
+    contract.functions.updateCreditlimits(B, 50, 100).transact({"from": A})
+    contract.functions.updateCreditlimits(A, 100, 50).transact({"from": B})
     assert len(contract.call().getUsers()) == 2
 
 
@@ -603,8 +603,8 @@ MAX_CREDITLINE = 2**CREDITLINE_WIDTH - 1
 def test_max_transfer(currency_network_contract, accounts):
     A, B, *rest = accounts
     contract = currency_network_contract
-    contract.functions.updateTrustline(B, MAX_CREDITLINE, MAX_CREDITLINE).transact({"from": A})
-    contract.functions.updateTrustline(A, MAX_CREDITLINE, MAX_CREDITLINE).transact({"from": B})
+    contract.functions.updateCreditlimits(B, MAX_CREDITLINE, MAX_CREDITLINE).transact({"from": A})
+    contract.functions.updateCreditlimits(A, MAX_CREDITLINE, MAX_CREDITLINE).transact({"from": B})
     contract.functions.transfer(B, MAX_CREDITLINE, 0, [B]).transact({"from": A})
 
     assert contract.functions.balance(A, B).call() == -MAX_CREDITLINE
@@ -613,8 +613,8 @@ def test_max_transfer(currency_network_contract, accounts):
 def test_overflow_max_transfer(currency_network_contract, accounts):
     A, B, *rest = accounts
     contract = currency_network_contract
-    contract.functions.updateTrustline(B, MAX_CREDITLINE, MAX_CREDITLINE).transact({"from": A})
-    contract.functions.updateTrustline(A, MAX_CREDITLINE, MAX_CREDITLINE).transact({"from": B})
+    contract.functions.updateCreditlimits(B, MAX_CREDITLINE, MAX_CREDITLINE).transact({"from": A})
+    contract.functions.updateCreditlimits(A, MAX_CREDITLINE, MAX_CREDITLINE).transact({"from": B})
     contract.functions.transfer(B, MAX_CREDITLINE, 0, [B]).transact({"from": A})
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
         contract.functions.transfer(B, 1, 0, [B]).transact({"from": A})

--- a/tests/test_gas_costs.py
+++ b/tests/test_gas_costs.py
@@ -80,7 +80,7 @@ def test_cost_transfer_3_mediators(web3, currency_network_contract_with_trustlin
 def test_cost_first_trustline_request(web3, currency_network_contract, accounts, table):
     contract = currency_network_contract
     A, B, *rest = accounts
-    tx_hash = contract.functions.updateTrustline(B, 150, 150).transact({"from": A})
+    tx_hash = contract.functions.updateCreditlimits(B, 150, 150).transact({"from": A})
     gas_cost = get_gas_costs(web3, tx_hash)
     report_gas_costs(table, 'First Trustline Update Request', gas_cost, limit=77000)
 
@@ -88,8 +88,8 @@ def test_cost_first_trustline_request(web3, currency_network_contract, accounts,
 def test_cost_second_trustline_request(web3, currency_network_contract, accounts, table):
     contract = currency_network_contract
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 149, 149).transact({"from": A})
-    tx_hash = contract.functions.updateTrustline(B, 150, 150).transact({"from": A})
+    contract.functions.updateCreditlimits(B, 149, 149).transact({"from": A})
+    tx_hash = contract.functions.updateCreditlimits(B, 150, 150).transact({"from": A})
     gas_cost = get_gas_costs(web3, tx_hash)
     report_gas_costs(table, 'Second Trustline Update Request', gas_cost, limit=47000)
 
@@ -98,8 +98,8 @@ def test_cost_first_trustline(web3, currency_network_contract, accounts, table):
     contract = currency_network_contract
     A, B, *rest = accounts
     assert contract.functions.creditline(A, B).call() == 0
-    contract.functions.updateTrustline(B, 150, 150).transact({"from": A})
-    tx_hash = contract.functions.updateTrustline(A, 150, 150).transact({"from": B})
+    contract.functions.updateCreditlimits(B, 150, 150).transact({"from": A})
+    tx_hash = contract.functions.updateCreditlimits(A, 150, 150).transact({"from": B})
     assert contract.functions.creditline(A, B).call() == 150
     gas_cost = get_gas_costs(web3, tx_hash)
     report_gas_costs(table, 'First Trustline', gas_cost, limit=315000)
@@ -109,8 +109,8 @@ def test_cost_update_trustline(web3, currency_network_contract_with_trustlines, 
     contract = currency_network_contract_with_trustlines
     A, B, *rest = accounts
     assert contract.functions.creditline(A, B).call() == 100
-    contract.functions.updateTrustline(B, 150, 150).transact({"from": A})
-    tx_hash = contract.functions.updateTrustline(A, 150, 150).transact({"from": B})
+    contract.functions.updateCreditlimits(B, 150, 150).transact({"from": A})
+    tx_hash = contract.functions.updateCreditlimits(A, 150, 150).transact({"from": B})
     assert contract.functions.creditline(A, B).call() == 150
     gas_cost = get_gas_costs(web3, tx_hash)
     report_gas_costs(table, 'Update Trustline', gas_cost, limit=56000)
@@ -120,7 +120,7 @@ def test_cost_update_reduce_need_no_accept_trustline(web3, currency_network_cont
     contract = currency_network_contract_with_trustlines
     A, B, *rest = accounts
     assert contract.functions.creditline(A, B).call() == 100
-    tx_hash = contract.functions.updateTrustline(B, 99, 150).transact({"from": A})
+    tx_hash = contract.functions.updateCreditlimits(B, 99, 150).transact({"from": A})
     assert contract.functions.creditline(A, B).call() == 99
     gas_cost = get_gas_costs(web3, tx_hash)
     report_gas_costs(table, 'Reduce Trustline', gas_cost, limit=66000)


### PR DESCRIPTION
Rename updateTrustline to updateCreditlimits for function without
interests. We had two functions before with the same name updateTrustlines
which causes problems in some libraries, for example the lightwallet lib we
used, because they do not handle that case properly.

Fixes #150