### PR TITLE
add a bit of infrastructure to test or call internal functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,8 @@ repos:
       language_version: python3.6
       additional_dependencies: ["flake8-invalid-escape-sequences", "flake8-string-format", "flake8-per-file-ignores"]
     - id: trailing-whitespace
+-   repo: https://github.com/schmir/solium-pre-commit
+    rev: 0.1.0
+    hooks:
+    - id: solium
+      args: [--dir=contracts]

--- a/.soliumignore
+++ b/.soliumignore
@@ -1,1 +1,4 @@
 node_modules
+build
+venv-populus
+venv

--- a/constraints.txt
+++ b/constraints.txt
@@ -12,7 +12,7 @@ cachetools==2.1.0
 certifi==2018.8.24
 cffi==1.11.5
 chardet==3.0.4
-click==6.7
+click==7.0
 coverage==4.5.1
 cryptography==2.3.1
 cytoolz==0.9.0.1

--- a/contracts/TestCurrencyNetwork.sol
+++ b/contracts/TestCurrencyNetwork.sol
@@ -1,0 +1,40 @@
+/*
+  The sole purpose of this file is to be able to test the internal functions of
+  the CurrencyNetwork or export test data to be used for testing the python
+  implementation of these functions
+*/
+
+
+import "./CurrencyNetwork.sol";
+
+contract TestCurrencyNetwork is CurrencyNetwork {
+    function TestCurrencyNetwork() public {
+        // don't do anything here due to upgradeability issues (no constructor-call on replacement).
+    }
+
+    function() external {}
+
+    function testCalculateFees(uint64 _imbalanceGenerated, uint16 _capacityImbalanceFeeDivisor)
+        public pure
+        returns (uint64)
+    {
+        return _calculateFees(_imbalanceGenerated, _capacityImbalanceFeeDivisor);
+    }
+
+    function testCalculateFeesReverse(uint64 _imbalanceGenerated, uint16 _capacityImbalanceFeeDivisor)
+        public pure
+        returns (uint64)
+    {
+        return _calculateFeesReverse(_imbalanceGenerated, _capacityImbalanceFeeDivisor);
+    }
+
+    function testImbalanceGenerated(
+        uint64 _value,
+        int72 _balance
+    )
+        public pure
+        returns (uint64)
+    {
+        return _imbalanceGenerated(_value, _balance);
+    }
+}

--- a/py-deploy/setup.py
+++ b/py-deploy/setup.py
@@ -43,7 +43,7 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=["contrib", "docs", "tests"]),
-    install_requires=["web3>=4.7.1,<4.8.0", "click", "trustlines-contracts-bin>=0.3.0,<0.4.0"],
+    install_requires=["web3>=4.7.1,<4.8.0", "click>=7.0", "trustlines-contracts-bin>=0.3.0,<0.4.0"],
     python_requires=">=3.5",
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow

--- a/py-deploy/tldeploy/cli.py
+++ b/py-deploy/tldeploy/cli.py
@@ -38,7 +38,8 @@ jsonrpc_option = click.option('--jsonrpc',
 currency_network_contract_name_option = click.option(
     '--currency-network-contract-name',
     help='name of the currency network contract to deploy (only use this for testing)',
-    default="CurrencyNetwork")
+    default="CurrencyNetwork",
+    hidden=True)
 
 
 @cli.command(short_help='Deploy a currency network contract.')

--- a/py-deploy/tldeploy/core.py
+++ b/py-deploy/tldeploy/core.py
@@ -108,9 +108,16 @@ def deploy_network(
     default_interest_rate=0,
     custom_interests=True,
     prevent_mediator_interests=False,
-    exchange_address=None
+    exchange_address=None,
+    currency_network_contract_name=None
 ):
-    currency_network = deploy("CurrencyNetwork", web3)
+    # CurrencyNetwork is the standard contract to deploy, If we're running
+    # tests or trying to export data for testing the python implementation of
+    # private functions, we may want deploy the TestCurrencyNetwork contract
+    # instead.
+    if currency_network_contract_name is None:
+        currency_network_contract_name = "CurrencyNetwork"
+    currency_network = deploy(currency_network_contract_name, web3)
 
     txid = currency_network.functions.init(name,
                                            symbol,
@@ -168,11 +175,18 @@ def deploy_proxied_network(web3, name, symbol, decimals, fee_divisor=100, exchan
     return proxied_trustlines
 
 
-def deploy_networks(web3, network_settings):
+def deploy_networks(web3, network_settings, currency_network_contract_name=None):
     exchange = deploy_exchange(web3)
     unw_eth = deploy_unw_eth(web3, exchange.address)
 
-    networks = [deploy_network(web3, exchange_address=exchange.address, **network_setting) for
-                network_setting in network_settings]
+    networks = [
+        deploy_network(
+            web3,
+            exchange_address=exchange.address,
+            currency_network_contract_name=currency_network_contract_name,
+            **network_setting,
+        )
+        for network_setting in network_settings
+    ]
 
     return networks, exchange, unw_eth


### PR DESCRIPTION
This commit adds a TestCurrencyNetwork contract that subclasses the
CurrencyNetwork contract. It provides additional methods that can be used to
call into internal functions of CurrencyNetwork.

It should only be used for development and testing. It could be used to test
internal functions or export test data for the corresponding python
implementation of these internal functions.

The tldeploy.core.deploy_network functions takes an additional parameter
currency_network_contract_name. If it's not set, the function will use the name
specified in the environment variable TRUSTLINES_CURRENCY_NETWORK_CONTRACT_NAME
or use the default "CurrencyNetwork".

This means, one can deploy the test contract by running

    TRUSTLINES_CURRENCY_NETWORK_CONTRACT_NAME=TestCurrencyNetwork tl-deploy ...