### PR TITLE
fix whitespace issues where our pre-commit hooks would complain

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,26 +5,26 @@ Change Log
 -----------------------
 * Added interests to currency networks
 
-  A trustline now also consists of two interest rates given by the two parties to each other. 
+  A trustline now also consists of two interest rates given by the two parties to each other.
   These interest rates are used to calculate occured interests between the two parties. The balance
-  including the interests is updated whenever the balance (because of a transfer) or one of 
-  the interest rates (because of a trustline update) changes. To calculate the interests we 
-  approximate Continuous Compounding with a taylor series and use the current timestamp and 
-  the timestamp of the last update. 
+  including the interests is updated whenever the balance (because of a transfer) or one of
+  the interest rates (because of a trustline update) changes. To calculate the interests we
+  approximate Continuous Compounding with a taylor series and use the current timestamp and
+  the timestamp of the last update.
 
-* Added interest settings to deploy tool 
+* Added interest settings to deploy tool
 
   The deploy tool now allows deploying networks with different interests settings. The current options
   are: Default interests: If this is set, every trustline has the same interest rate.
   Custom interest: If this is set, every user can decide which interest rate he want to give.
-  Prevent mediator interests: Safe setting to prevent mediators from paying interests for 
-  mediated transfer by disallowing certain transfers. 
+  Prevent mediator interests: Safe setting to prevent mediators from paying interests for
+  mediated transfer by disallowing certain transfers.
 
 * Close a trustline
 
   Added a new function to do a triangular payment to close a trustline. This will set the balance
   between two user to zero and also removes all information about this trustline. This is still work
-  in progress and might change. 
+  in progress and might change.
 
 `0.2.0`_ (2018-09-19)
 -----------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,5 @@
 ## Contributing
 
-You need to sign the Trustlines Network CLA (Contributor License Agreement). 
-Our CLA bot will help you with that after you created a pull request. 
+You need to sign the Trustlines Network CLA (Contributor License Agreement).
+Our CLA bot will help you with that after you created a pull request.
 If you or your employer do not hold the whole copyright of the authorship submitted we can not accept your contribution.
-
-
-

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -642,4 +642,3 @@ contract Exchange is SafeMath, Destructable {
         return Token(token).allowance.gas(EXTERNAL_QUERY_GAS_LIMIT)(owner, this); // Limit gas to prevent reentrancy
     }
 }
-

--- a/contracts/lib/Authorizable.sol
+++ b/contracts/lib/Authorizable.sol
@@ -70,4 +70,3 @@ contract Authorizable is Ownable {
         emit LogAuthorizedAddressRemoved(target, msg.sender);
     }
 }
-

--- a/contracts/lib/Destructable.sol
+++ b/contracts/lib/Destructable.sol
@@ -15,4 +15,3 @@ contract Destructable is Ownable {
         selfdestruct(owner);
     }
 }
-

--- a/contracts/lib/Ownable.sol
+++ b/contracts/lib/Ownable.sol
@@ -26,4 +26,3 @@ contract Ownable {
         }
     }
 }
-

--- a/contracts/lib/SafeMath.sol
+++ b/contracts/lib/SafeMath.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.4.11;
 contract SafeMath {
     function safeMul(uint a, uint b)
         internal
-        constant 
-        returns (uint256) 
+        constant
+        returns (uint256)
     {
         uint c = a * b;
         assert(a == 0 || c / a == b);
@@ -13,63 +13,62 @@ contract SafeMath {
     }
 
     function safeDiv(uint a, uint b)
-        internal 
-        constant 
-        returns (uint256) 
+        internal
+        constant
+        returns (uint256)
     {
         uint c = a / b;
         return c;
     }
 
-    function safeSub(uint a, uint b) 
-        internal 
-        constant 
-        returns (uint256) 
+    function safeSub(uint a, uint b)
+        internal
+        constant
+        returns (uint256)
     {
         assert(b <= a);
         return a - b;
     }
 
-    function safeAdd(uint a, uint b) 
-        internal 
-        constant 
-        returns (uint256) 
+    function safeAdd(uint a, uint b)
+        internal
+        constant
+        returns (uint256)
     {
         uint c = a + b;
         assert(c >= a);
         return c;
     }
 
-    function max64(uint64 a, uint64 b) 
-        internal 
-        constant 
-        returns (uint64) 
+    function max64(uint64 a, uint64 b)
+        internal
+        constant
+        returns (uint64)
     {
         return a >= b ? a : b;
     }
 
-    function min64(uint64 a, uint64 b) 
-        internal 
-        constant 
-        returns (uint64) 
+    function min64(uint64 a, uint64 b)
+        internal
+        constant
+        returns (uint64)
     {
         return a < b ? a : b;
     }
 
-    function max256(uint256 a, uint256 b) 
-        internal 
-        constant 
-        returns (uint256) 
+    function max256(uint256 a, uint256 b)
+        internal
+        constant
+        returns (uint256)
     {
         return a >= b ? a : b;
     }
 
-    function min256(uint256 a, uint256 b) 
-        internal 
-        constant 
-        returns (uint256) 
+    function min256(uint256 a, uint256 b)
+        internal
+        constant
+        returns (uint256)
     {
         return a < b ? a : b;
     }
 }
-

--- a/contracts/tokens/DummyToken.sol
+++ b/contracts/tokens/DummyToken.sol
@@ -38,4 +38,3 @@ contract DummyToken is Ownable, StandardToken, SafeMath {
         balances[_target] = _value;
     }
 }
-

--- a/contracts/tokens/StandardToken.sol
+++ b/contracts/tokens/StandardToken.sol
@@ -47,4 +47,3 @@ contract StandardToken is Token {
     mapping (address => mapping (address => uint)) allowed;
     uint public totalSupply;
 }
-

--- a/contracts/tokens/Token.sol
+++ b/contracts/tokens/Token.sol
@@ -37,4 +37,3 @@ contract Token {
     event Transfer(address indexed _from, address indexed _to, uint _value);
     event Approval(address indexed _owner, address indexed _spender, uint _value);
 }
-

--- a/py-bin/set_npm_version.sh
+++ b/py-bin/set_npm_version.sh
@@ -3,4 +3,3 @@
 
  VERSION=$(python3 -c 'from setuptools_scm import get_version; print(get_version(root="..").replace(".dev", "-dev").replace("+", "."))')
  npm version "$VERSION" --allow-same-version
-


### PR DESCRIPTION
This is the result of running 'pre-commit run -a'. It removes trailing
whitespace and multiple empty lines at the end of the file.