### PR TITLE
enhance our Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ target/
 #project
 networks
 /py-bin/contracts.json
+/.requirements-installed

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ pytest
 texttable
 setuptools_scm
 eth-tester[py-evm]
+# require a recent pip version, otherwise make install may silently fail to
+# install the newly compiled contracts
+pip>=18.1


### PR DESCRIPTION
We've had problems with pip yesterday. make install wouldn't reinstall the
py-bin package. The reason was that pip version 9 was too old for this to work.

This is now solved by installing our requirements into the local virtualenv and
including pip>=18.1 in our requiremnts.

We're now able to run just make install in an empty virtulenv and get a working
environment.