### PR TITLE
update pre-commit hooks to 2.0, disallow commits to develop branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v0.9.1
+    sha: v2.0.0
     hooks:
     - id: check-added-large-files
     - id: check-ast
@@ -16,8 +16,10 @@ repos:
       exclude: .bumpversion.cfg
     - id: flake8
       language_version: python3.6
-      additional_dependencies: ["flake8-invalid-escape-sequences", "flake8-string-format", "flake8-per-file-ignores"]
+      additional_dependencies: ["flake8-string-format", "flake8-per-file-ignores"]
     - id: trailing-whitespace
+    - id: no-commit-to-branch
+      args: [--branch, develop, --branch, master]
 -   repo: https://github.com/schmir/Ethlint.git
     rev: bbbac907e7352d59fcd133f73295a042a2cdcb17
     hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,14 +6,14 @@ Change Log
 * Remove the fees on the last hop
 
   A user now only has to pay fees to the true mediators and not anymore to the receiver.
-  
+
 * Add transfer function where receiver pays the fees
 
   It is now possible to make payments, where the receiver will pay the fees.
 
 * Round up fees
 
-  We are now properly rounding up the fees, where before we used an own formular that was 
+  We are now properly rounding up the fees, where before we used an own formular that was
   already close to rounding up.
 
 * Bug Fix #159
@@ -22,16 +22,16 @@ Change Log
 `0.3.3`_ (2018-11-28)
 -----------------------
 * Bug fix deploy tool so that it is possible to deploy a network with zero fees
-* First version of trustlines-contracts-abi on npm. 
-  
+* First version of trustlines-contracts-abi on npm.
+
 `0.3.2`_ (2018-11-26)
 -----------------------
 * Optimize gas cost of contracts
-  
+
 `0.3.1`_ (2018-11-13)
 -----------------------
-* Fix a dependency issue  
-  
+* Fix a dependency issue
+
 `0.3.0`_ (2018-11-12)
 -----------------------
 * Added interests to currency networks


### PR DESCRIPTION
also remove flake8-invalid-escape-sequences, which isn't needed anymore with a
recent flake8.