### PR TITLE
use new constructor() syntax for constructors

### DIFF
--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.25;
 
 
 import "./lib/it_set_lib.sol";
@@ -120,7 +120,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         _;
     }
 
-    function CurrencyNetwork() public {
+    constructor() public {
         // don't do anything here due to upgradeability issues (no constructor-call on replacement).
     }
 

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.25;
 
 import "./tokens/Token.sol";
 import "./lib/SafeMath.sol";
@@ -87,7 +87,7 @@ contract Exchange is SafeMath, Destructable {
         bytes32 orderHash;
     }
 
-    function Exchange() public {
+    constructor() public {
     }
 
     /*

--- a/contracts/TestCurrencyNetwork.sol
+++ b/contracts/TestCurrencyNetwork.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.25;
 
 /*
   The sole purpose of this file is to be able to test the internal functions of
@@ -11,7 +11,7 @@ import "./CurrencyNetwork.sol";
 
 
 contract TestCurrencyNetwork is CurrencyNetwork {
-    function TestCurrencyNetwork() public {
+    constructor() public {
         // don't do anything here due to upgradeability issues (no constructor-call on replacement).
     }
 

--- a/contracts/lib/Ownable.sol
+++ b/contracts/lib/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.25;
 
 /*
  * Ownable
@@ -11,7 +11,7 @@ pragma solidity ^0.4.11;
 contract Ownable {
     address public owner;
 
-    function Ownable() public {
+    constructor() public {
         owner = msg.sender;
     }
 


### PR DESCRIPTION
This is the preferred way to implement a constructor and is mandatory for
solidity 0.5 or up.

See https://github.com/trustlines-network/contracts/issues/168