### PR TITLE
Create identity contract

### DIFF
--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.4.25;
+
+import "./lib/ECDSA.sol";
+
+
+contract Identity {
+
+    address private owner;
+    bool private initialised;
+
+    constructor() public {
+        // don't do anything here to allow usage of proxy contracts.
+    }
+
+    function init(address _owner) public {
+        require(! initialised, "The contract has already been initialised.");
+        owner = _owner;
+        initialised = true;
+    }
+
+    function executeDelegatedTransaction(bytes _data, bytes _signature) public returns (bool _success) {
+        require(isSignatureFromOwner(_data, _signature), "The provided data was signed by the owner of the identity.");
+        _success = true;
+    }
+
+    function isSignatureFromOwner(bytes _data, bytes _signature) internal view returns (bool) {
+        bytes32 hash = keccak256(_data);
+        address signer = ECDSA.recover(hash, _signature);
+        return owner == signer;
+    }
+}

--- a/contracts/TestIdentity.sol
+++ b/contracts/TestIdentity.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.4.25;
+
+/*
+  The sole purpose of this file is to be able to test the internal functions of the identity contract
+*/
+
+
+import "./Identity.sol";
+
+
+contract TestIdentity is Identity {
+
+    function testIsSignatureFromOwner(bytes _data, bytes _signature) public view returns (bool) {
+        return isSignatureFromOwner(_data, _signature);
+    }
+}

--- a/contracts/lib/ECDSA.sol
+++ b/contracts/lib/ECDSA.sol
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Smart Contract Solutions, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+pragma solidity ^0.4.24;
+
+/**
+ * @title Elliptic curve signature operations
+ * @dev Based on https://gist.github.com/axic/5b33912c6f61ae6fd96d6c4a47afde6d
+ * TODO Remove this library once solidity supports passing a signature to ecrecover.
+ * See https://github.com/ethereum/solidity/issues/864
+ */
+
+library ECDSA {
+    /**
+     * @dev Recover signer address from a message by using their signature
+     * @param hash bytes32 message, the hash is the signed message. What is recovered is the signer address.
+     * @param signature bytes signature, the signature is generated using web3.eth.sign()
+     */
+    function recover(bytes32 hash, bytes signature) internal pure returns (address) {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+
+        // Check the signature length
+        if (signature.length != 65) {
+            return (address(0));
+        }
+
+        // Divide the signature in r, s and v variables
+        // ecrecover takes the signature parameters, and the only way to get them
+        // currently is to use assembly.
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            v := byte(0, mload(add(signature, 0x60)))
+        }
+
+        // Version of signature should be 27 or 28, but 0 and 1 are also possible versions
+        if (v < 27) {
+            v += 27;
+        }
+
+        // If the version is correct return the signer address
+        if (v != 27 && v != 28) {
+            return (address(0));
+        } else {
+            // solium-disable-next-line arg-overflow
+            return ecrecover(hash, v, r, s);
+        }
+    }
+
+    /**
+     * toEthSignedMessageHash
+     * @dev prefix a bytes32 value with "\x19Ethereum Signed Message:"
+     * and hash the result
+     */
+    function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {
+        // 32 is the length in bytes of hash,
+        // enforced by the type signature above
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
+    }
+}

--- a/py-deploy/tldeploy/core.py
+++ b/py-deploy/tldeploy/core.py
@@ -190,3 +190,12 @@ def deploy_networks(web3, network_settings, currency_network_contract_name=None)
     ]
 
     return networks, exchange, unw_eth
+
+
+def deploy_identity(web3, identiy_contract_name=None):
+
+    if identiy_contract_name is None:
+        identiy_contract_name = "Identity"
+    identity_contract = deploy(identiy_contract_name, web3)
+
+    return identity_contract

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,56 @@
+#! pytest
+
+import pytest
+import eth_tester.exceptions
+from tldeploy.core import deploy_identity
+
+
+@pytest.fixture()
+def test_identity_contract(web3):
+    return deploy_identity(web3, "TestIdentity")
+
+
+@pytest.fixture()
+def test_identity_contract_owned_by_0(test_identity_contract, web3, accounts):
+
+    owner = accounts[0]
+    test_identity_contract.functions.init(owner).transact({'from': accounts[0]})
+    return test_identity_contract
+
+
+@pytest.fixture()
+def key_0(ethereum_tester, accounts):
+    return ethereum_tester.backend.account_keys[0]
+
+
+def test_init_already_init(test_identity_contract_owned_by_0, accounts):
+
+    with pytest.raises(eth_tester.exceptions.TransactionFailed):
+        test_identity_contract_owned_by_0.functions.init(accounts[0]).transact({'from': accounts[0]})
+
+
+def test_signature_from_owner(test_identity_contract_owned_by_0, key_0, accounts):
+
+    data = (1234).to_bytes(10, byteorder='big')
+    signature = key_0.sign_msg(data).to_bytes()
+
+    assert test_identity_contract_owned_by_0.functions.testIsSignatureFromOwner(data, signature).call() is True
+
+
+def test_signature_not_owner(test_identity_contract_owned_by_0, key_0, ethereum_tester, accounts):
+
+    data = (1234).to_bytes(10, byteorder='big')
+    private_key = ethereum_tester.backend.account_keys[1]
+    signature = private_key.sign_msg(data).to_bytes()
+
+    assert test_identity_contract_owned_by_0.functions.testIsSignatureFromOwner(data, signature).call() is False
+
+
+def test_wrong_signature_from_owner(test_identity_contract_owned_by_0, key_0, accounts):
+
+    data = (1234).to_bytes(10, byteorder='big')
+    wrong_data = (12345678).to_bytes(10, byteorder='big')
+
+    signature = key_0.sign_msg(data).to_bytes()
+
+    assert test_identity_contract_owned_by_0.functions.testIsSignatureFromOwner(wrong_data, signature).call() is False


### PR DESCRIPTION
The identity contract can store the address of an owner
It can verify that a message sent was signed by the owner
Closes https://github.com/trustlines-network/contracts/issues/178