### PR TITLE
Add validation to delegator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,8 @@ repos:
     hooks:
     - id: solium
       args: [--dir=contracts]
+- repo: git://github.com/luismayta/pre-commit-mypy
+  sha: '0.1.1'
+  hooks:
+  - id: mypy
+    args: ["--scripts-are-modules", "--ignore-missing-imports"]

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -6,6 +6,7 @@
     "function-order": "error",
     "mixedcase": "error",
     "quotes": ["error", "double"],
+    "error-reason": "error",
     "security/no-inline-assembly": "off",
     "security/no-block-members": "off",
     "operator-whitespace": "off"

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -49,8 +49,8 @@ contract Identity {
             extraData
         );
 
-        require(isSignatureValid(hash, signature), "The transaction signature is not valid");
-        require(isNonceValid(nonce, hash), "The transaction nonce is invalid");
+        require(validateSignature(hash, signature), "The transaction signature is not valid");
+        require(validateNonce(nonce, hash), "The transaction nonce is invalid");
 
         if (nonce == 0) {
             hashUsed[hash] = true; // To prevent replaying this meta transaction
@@ -65,7 +65,7 @@ contract Identity {
         _success = true;
     }
 
-    function isNonceValid(uint nonce, bytes32 hash) public view returns (bool) {
+    function validateNonce(uint nonce, bytes32 hash) public view returns (bool) {
         if (nonce == 0) {
             return !hashUsed[hash];
         } else {
@@ -74,7 +74,7 @@ contract Identity {
 
     }
 
-    function isSignatureValid(bytes32 hash, bytes _signature) public view returns (bool) {
+    function validateSignature(bytes32 hash, bytes _signature) public view returns (bool) {
         address signer = ECDSA.recover(hash, _signature);
         return owner == signer;
     }

--- a/contracts/tests/TestContract.sol
+++ b/contracts/tests/TestContract.sol
@@ -23,6 +23,6 @@ contract TestContract {
     }
 
     function fails() public {
-        revert();
+        revert("This will just always fail");
     }
 }

--- a/contracts/tests/TestIdentity.sol
+++ b/contracts/tests/TestIdentity.sol
@@ -10,10 +10,6 @@ import "../Identity.sol";
 
 contract TestIdentity is Identity {
 
-    function testIsSignatureValid(bytes32 _data, bytes _signature) public view returns (bool) {
-        return isSignatureValid(_data, _signature);
-    }
-
     function testTransactionHash(
         address from,
         address to,


### PR DESCRIPTION
Add methods to allow to validate a meta transaction
before sending it
Also send_meta_transaction now returns the hash of the
envelop transaction